### PR TITLE
Remove the array filter method to always show the totalResults and support the Microsoft SCIM validator

### DIFF
--- a/src/SCIM/ListResponse.php
+++ b/src/SCIM/ListResponse.php
@@ -29,7 +29,7 @@ class ListResponse implements Jsonable
 
     public function toSCIMArray()
     {
-        return array_filter([
+        return [
             'totalResults' => $this->totalResults,
             "itemsPerPage" => count($this->resourceObjects->toArray()),
 
@@ -42,6 +42,6 @@ class ListResponse implements Jsonable
                 "urn:ietf:params:scim:api:messages:2.0:ListResponse"
             ],
             'Resources' => Helper::prepareReturn($this->resourceObjects, $this->resourceType, $this->attributes),
-        ]);
-        }
+        ];
+    }
 }


### PR DESCRIPTION
What is the reason for filtering this array? https://scimvalidator.microsoft.com/ expects the totalResults to be always present even when zero.