### PR TITLE
Support for multivalue patching

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -170,7 +170,7 @@ class ResourceController extends Controller
                     break;
 
                 case "replace":
-                    if (is_array($operation['value'])) {
+                    if (is_array($operation['value']) && !isset($operation['path'])) {
                         foreach ($operation['value'] as $key => $value) {
                             $resourceType->getMapping()->patch('replace', $value, $resourceObject, ParserParser::parse($key ?? null));
                         }

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -170,7 +170,13 @@ class ResourceController extends Controller
                     break;
 
                 case "replace":
-                    $resourceType->getMapping()->patch('replace', $operation['value'], $resourceObject, ParserParser::parse($operation['path'] ?? null));
+                    if (is_array($operation['value'])) {
+                        foreach ($operation['value'] as $key => $value) {
+                            $resourceType->getMapping()->patch('replace', $value, $resourceObject, ParserParser::parse($key ?? null));
+                        }
+                    } else{
+                        $resourceType->getMapping()->patch('replace', $operation['value'], $resourceObject, ParserParser::parse($operation['path'] ?? null));
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
Microsoft SCIM validator uses multivalue replace operations. This PR adds support for that.

```json
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
  ],
  "Operations": [
    {
      "op": "replace",
      "value": {
        "active": true,
        "name.givenName": "Hello world!"
      }
    }
  ]
}
```