### PR TITLE
Allow not returning certain attributes

### DIFF
--- a/src/Attribute/Attribute.php
+++ b/src/Attribute/Attribute.php
@@ -39,6 +39,7 @@ class Attribute
     protected $type = 'string';
     protected $description = null;
     protected $defaultValue = null;
+    protected $returned = 'default';
 
     public $dirty = false;
 
@@ -68,7 +69,7 @@ class Attribute
             'name' => $this->name,
             'type' => $this->type,
             'mutability' => $this->mutability,
-            'returned' => 'default',
+            'returned' => $this->returned,
             'uniqueness' => 'server',
             'required' => $this->isRequired(),
             'multiValued' => $this->getMultiValued(),
@@ -133,6 +134,11 @@ class Attribute
         return true;
     }
 
+    public function setReturned($returned){
+        $this->returned = $returned;
+        return $this;
+    }
+
     public function setParent($parent)
     {
         $this->parent = $parent;
@@ -147,6 +153,10 @@ class Attribute
     {
         // check if name or getFullKey is in attributes
         if (!$this->isRequested($attributes)) {
+            return null;
+        }
+
+        if($this->returned == 'never'){
             return null;
         }
 

--- a/src/SCIMConfig.php
+++ b/src/SCIMConfig.php
@@ -78,7 +78,7 @@ class SCIMConfig
                     eloquent('userName', 'name')->ensure('required'),
                     eloquent('active')->ensure('boolean')->default(false),
                     complex('name')->withSubAttributes(eloquent('formatted')),
-                    eloquent('password')->ensure('nullable'),
+                    eloquent('password')->ensure('nullable')->setReturned('never'),
                     (new class ('emails') extends Complex {
                         protected function doRead(&$object, $attributes = [])
                         {

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -369,6 +369,7 @@ class BasicTest extends TestCase
         $this->assertArrayHasKey('urn:ietf:params:scim:schemas:core:2.0:User', $json);
         $this->assertEquals('mariejo@example.com', $json['urn:ietf:params:scim:schemas:core:2.0:User']['emails'][0]['value']);
         $this->assertEquals('Dr. Marie Jo', $json['urn:ietf:params:scim:schemas:core:2.0:User']['userName']);
+        $this->assertArrayNotHasKey('password', $json['urn:ietf:params:scim:schemas:core:2.0:User']);
     }
 
     public function testPostTopLevel()


### PR DESCRIPTION
This is now supported:

~~~.php
// Note setReturned
eloquent('password')->ensure('nullable')->setReturned('never')
~~~