### PR TITLE
Search all schema nodes for value

### DIFF
--- a/src/Attribute/AbstractComplex.php
+++ b/src/Attribute/AbstractComplex.php
@@ -52,9 +52,14 @@ abstract class AbstractComplex extends Attribute
     {
         $result = collect($this->subAttributes)->first(fn ($element) => $element->name == $key);
 
-        // if this is the root node, search for a subNode in one of the default schema nodes
-        if($result == null){
-            $result = $this->getSchemaNode()?->getSubNode($key);
+        // if this is the root node, search for a subNode in all of the default schema nodes
+        if ($result == null) {
+            foreach ($this->getSchemaNodes() as $schema) {
+                if ($schema->getSubNode($key)) {
+                    $result = $schema->getSubNode($key);
+                    continue;
+                }
+            }
         }
 
         return $result;


### PR DESCRIPTION
This covers the enterprise options when a value needs to be added or replaced. The current implementation will only search `urn:ietf:params:scim:schemas:core:2.0:User` when the value may be in `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`