### PR TITLE
Fix separator variable name in Attribute::getFullKey

### DIFF
--- a/src/Attribute/Attribute.php
+++ b/src/Attribute/Attribute.php
@@ -191,8 +191,8 @@ class Attribute
     public function getFullKey()
     {
         if ($this->parent != null && $this->parent->name != null) {
-            $seperator = $this->parent instanceof AttributeSchema ? ':' : '.';
-            return $this->parent->getFullKey() . $seperator . $this->name;
+            $separator = $this->parent instanceof AttributeSchema ? ':' : '.';
+            return $this->parent->getFullKey() . $separator . $this->name;
         } else {
             return $this->name;
         }


### PR DESCRIPTION
## Summary
- rename `$seperator` to `$separator` in `getFullKey`

## Testing
- `composer install` *(fails: Your lock file does not contain a compatible set of packages. Please run composer update.)*
- `composer install --ignore-platform-req=php` *(fails: requires GitHub token to download packages)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l src/Attribute/Attribute.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac35f2972c8328a7ea9725ac5f1d8f