### PR TITLE
Group OR filter terms so they cannot bypass base query constraints

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -146,13 +146,21 @@ class Helper
                 );
             }
         } elseif ($node instanceof Disjunction) {
-            foreach ($node->getTerms() as $term) {
-                $query->orWhere(
-                    function ($query) use ($term, $resourceType) {
-                        Helper::scimFilterToLaravelQuery($resourceType, $query, new ParserPath($term, $term->dump()));
+            // Group the OR terms so they cannot bypass constraints already
+            // present on the builder, e.g. scoping applied by the resource
+            // type's base query.
+            $query->where(
+                function (Builder $nested) use ($node, $resourceType) {
+                    foreach ($node->getTerms() as $index => $term) {
+                        $method = $index === 0 ? 'where' : 'orWhere';
+                        $nested->{$method}(
+                            function ($query) use ($term, $resourceType) {
+                                Helper::scimFilterToLaravelQuery($resourceType, $query, new ParserPath($term, $term->dump()));
+                            }
+                        );
                     }
-                );
-            }
+                }
+            );
         } elseif ($node instanceof ValuePath) {
             $attribute = static::resolveAttributeChain($resourceType->getMapping(), $path->getValuePathAttributes());
 

--- a/tests/FilterQueryTest.php
+++ b/tests/FilterQueryTest.php
@@ -2,6 +2,9 @@
 
 namespace ArieTimmerman\Laravel\SCIMServer\Tests;
 
+use ArieTimmerman\Laravel\SCIMServer\Helper;
+use ArieTimmerman\Laravel\SCIMServer\Parser\Parser;
+use ArieTimmerman\Laravel\SCIMServer\ResourceType;
 use ArieTimmerman\Laravel\SCIMServer\Tests\Model\Group;
 use ArieTimmerman\Laravel\SCIMServer\Tests\Model\User;
 
@@ -122,6 +125,36 @@ class FilterQueryTest extends TestCase
         $this->assertFalse(
             $ids->contains((string)$userNameOnlyUser->id),
             'User matching only the userName condition should be excluded.'
+        );
+    }
+
+    public function testOrFilterDoesNotBypassScopedBaseQuery(): void
+    {
+        $inScopeUser = factory(User::class)->create([
+            'name' => 'in-scope-user',
+            'active' => true,
+        ]);
+
+        $outOfScopeUser = factory(User::class)->create([
+            'name' => 'out-of-scope-user',
+            'active' => false,
+        ]);
+
+        $query = User::where('active', true);
+
+        $filter = sprintf('userName eq "%s" or userName eq "%s"', $inScopeUser->name, $outOfScopeUser->name);
+
+        Helper::scimFilterToLaravelQuery(ResourceType::user(), $query, Parser::parseFilter($filter));
+
+        $ids = $query->pluck('id');
+
+        $this->assertTrue(
+            $ids->contains($inScopeUser->id),
+            'User matching the filter and the base query scope should be returned.'
+        );
+        $this->assertFalse(
+            $ids->contains($outOfScopeUser->id),
+            'OR terms in the filter must not bypass constraints on the base query.'
         );
     }
 


### PR DESCRIPTION
## Problem

`Helper::scimFilterToLaravelQuery` applies each disjunction (`or`) term with
`orWhere` directly on the builder it receives. That is only safe when the
resource type query has no pre-existing constraints (the package default).
When the base query is scoped — e.g. a custom config supplies
`'query' => User::where(...)` to exclude internal users — the ungrouped OR
terms attach at the same boolean level as that scoping and bypass it:

    WHERE scope OR term1 OR term2

This returns unfiltered results and leaks scoped-out records to SCIM clients.

## Fix

Wrap the disjunction terms in a nested `where` group, producing:

    WHERE scope AND (term1 OR term2)

This mirrors the grouping the same file already uses for disjunctions in the
valuePath/collection filter context (`applyFilterInCollectionContext`).

## Testing

Added `FilterQueryTest::testOrFilterDoesNotBypassScopedBaseQuery`, which
applies an `or` filter to a pre-constrained builder and asserts scoped-out
records stay excluded. The test fails against the previous implementation and
passes with this change; the full suite passes (75 tests, 547 assertions).